### PR TITLE
Add Automated Traffic Badge Generation

### DIFF
--- a/.github/workflows/traffic-badges.yml
+++ b/.github/workflows/traffic-badges.yml
@@ -1,0 +1,33 @@
+name: Update Traffic Badges
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Clone Badge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ./scripts/update_clone_badge.sh
+
+      - name: Update View Badge
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash ./scripts/update_view_badge.sh
+
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add clones.json views.json .github/badges/*.svg
+          git commit -m "Update traffic badges" || echo "No changes"
+          git push

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 [![demo platform](https://img.shields.io/badge/Play%20with%20LightDiffusion%21-LightDiffusion%20demo%20platform-lightblue)](https://huggingface.co/spaces/Aatricks/LightDiffusion-Next)&nbsp;
 
+![Clone Count](https://raw.githubusercontent.com/Aatricks/LightDiffusion-Next/main/.github/badges/clones.svg)
+
+![View Count](https://raw.githubusercontent.com/Aatricks/LightDiffusion-Next/main/.github/badges/views.svg)
+
 **LightDiffusion-Next**  is the fastest AI-powered image generation WebUI, combining speed, precision, and flexibility in one cohesive tool.
 </br>
 </br>

--- a/scripts/update_clone_badge.sh
+++ b/scripts/update_clone_badge.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="Aatricks/LightDiffusion-Next"
+TOKEN="${GITHUB_TOKEN}"
+
+BADGE_PATH=".github/badges/clones.svg"
+DATA_PATH="clones.json"
+
+json=$(curl -s -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/traffic/clones")
+
+clones_14d=$(echo "$json" | grep -o '"count":[0-9]*' | cut -d: -f2 | paste -sd+ - | bc)
+clones_14d=${clones_14d:-0}
+
+if [ ! -f "$DATA_PATH" ]; then
+    echo '{"history":[]}' > "$DATA_PATH"
+fi
+
+date=$(date -u +"%Y-%m-%d")
+tmp=$(mktemp)
+jq --arg d "$date" --argjson c "$clones_14d" \
+   '.history += [{date:$d, clones:$c}]' \
+   "$DATA_PATH" > "$tmp"
+mv "$tmp" "$DATA_PATH"
+
+total=$(jq '[.history[].clones] | add // 0' "$DATA_PATH")
+
+mkdir -p "$(dirname "$BADGE_PATH")"
+
+cat > "$BADGE_PATH" <<EOF
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+  <stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<mask id="a">
+  <rect width="160" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="110" height="20" fill="#555"/>
+  <rect x="110" width="50" height="20" fill="#007ec6"/>
+  <rect width="160" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle"
+   font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="55" y="15">clones</text>
+  <text x="135" y="15">$total</text>
+</g>
+</svg>
+EOF

--- a/scripts/update_view_badge.sh
+++ b/scripts/update_view_badge.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="Aatricks/LightDiffusion-Next"
+TOKEN="${GITHUB_TOKEN}"
+
+BADGE_PATH=".github/badges/views.svg"
+DATA_PATH="views.json"
+
+json=$(curl -s -H "Authorization: Bearer $TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$REPO/traffic/views")
+
+views_14d=$(echo "$json" | grep -o '"count":[0-9]*' | cut -d: -f2 | paste -sd+ - | bc)
+views_14d=${views_14d:-0}
+
+if [ ! -f "$DATA_PATH" ]; then
+    echo '{"history":[]}' > "$DATA_PATH"
+fi
+
+date=$(date -u +"%Y-%m-%d")
+tmp=$(mktemp)
+jq --arg d "$date" --argjson c "$views_14d" \
+   '.history += [{date:$d, views:$c}]' \
+   "$DATA_PATH" > "$tmp"
+mv "$tmp" "$DATA_PATH"
+
+total=$(jq '[.history[].views] | add // 0' "$DATA_PATH")
+
+mkdir -p "$(dirname "$BADGE_PATH")"
+
+cat > "$BADGE_PATH" <<EOF
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="20">
+<linearGradient id="b" x2="0" y2="100%">
+  <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+  <stop offset="1" stop-opacity=".1"/>
+</linearGradient>
+<mask id="a">
+  <rect width="160" height="20" rx="3" fill="#fff"/>
+</mask>
+<g mask="url(#a)">
+  <rect width="110" height="20" fill="#555"/>
+  <rect x="110" width="50" height="20" fill="#007ec6"/>
+  <rect width="160" height="20" fill="url(#b)"/>
+</g>
+<g fill="#fff" text-anchor="middle"
+   font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <text x="55" y="15">views</text>
+  <text x="135" y="15">$total</text>
+</g>
+</svg>
+EOF


### PR DESCRIPTION
This pull request adds automated tracking and display of GitHub repository traffic statistics (clones and views) as badges in the `README.md`. It introduces scripts and a GitHub Actions workflow to update these badges daily, providing up-to-date visibility into repository traffic.

**Automated Traffic Badge Generation and Updates:**

* Added a GitHub Actions workflow (`.github/workflows/traffic-badges.yml`) to run daily and on demand, which executes scripts to update traffic badges and commits the results.
* Introduced two scripts, `scripts/update_clone_badge.sh` and `scripts/update_view_badge.sh`, to fetch traffic data from the GitHub API, maintain historical data, and generate SVG badges showing total clones and views. [[1]](diffhunk://#diff-77111ec8287256ce53b07302003d22a52918455a7546d4e479e083fa120a29aaR1-R52) [[2]](diffhunk://#diff-61156521ce6258f19298c41b35b54f2f6adc6a64518e04e935454685fd666be7R1-R52)

**README Badge Integration:**

* Updated `README.md` to display the new clone and view badges, making repository traffic statistics visible to all visitors.