### PR TITLE
ROCm and mps

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ With its unmatched speed and efficiency, LightDiffusion-Next sets the benchmark 
 ---
 
 ## 🛠 Installation
+
+> [!NOTE]
+> **Platform Support:** LightDiffusion-Next supports NVIDIA GPUs (CUDA), AMD GPUs (ROCm), and Apple Silicon (Metal/MPS). For AMD and Apple Silicon setup instructions, see the [ROCm and Metal/MPS Support Guide](https://aatrick.github.io/LightDiffusion/rocm-metal-support/).
+
 > [!WARNING]
 > **Disclaimer:** On Linux, the fastest way to get started is with the Docker setup below. Windows users often encounter an `EOF` build error when using Docker; if that happens, set up a local virtual environment instead and install SageAttention inside it.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,11 +4,14 @@ LightDiffusion-Next can run locally on Windows or Linux, inside Docker, or on cl
 
 ## Hardware & software requirements
 
-The project is tuned for NVIDIA GPUs and CUDA 12.x drivers, but it can also operate on CPU for experimentation.
+The project is tuned for NVIDIA GPUs and CUDA 12.x drivers, but it also supports AMD GPUs with ROCm and Apple Silicon with Metal Performance Shaders (MPS). See [ROCm and Metal/MPS Support](rocm-metal-support.md) for platform-specific installation instructions.
 
-- **Operating system:** Windows 10/11, Ubuntu 22.04+, or any distro supported by NVIDIA Container Toolkit.
+- **Operating system:** Windows 10/11, Ubuntu 22.04+, macOS 12.3+ (for Apple Silicon), or any distro supported by NVIDIA Container Toolkit.
 - **Python:** 3.10.x. The run scripts create a virtual environment automatically.
-- **GPU:** NVIDIA card with at least compute capability 8.0 (Ampere) for SageAttention/SpargeAttn. RTX 50 series (compute 12.0) runs with SageAttention + Stable-Fast; SpargeAttn is skipped automatically.
+- **GPU:** 
+  - **NVIDIA:** Card with at least compute capability 8.0 (Ampere) for SageAttention/SpargeAttn. RTX 50 series (compute 12.0) runs with SageAttention + Stable-Fast.
+  - **AMD:** RDNA 2+ or CDNA architectures with ROCm 5.0+. See [ROCm Support](rocm-metal-support.md#rocm-support-amd-gpus).
+  - **Apple Silicon:** M1/M2/M3 series with macOS 12.3+. See [Metal/MPS Support](rocm-metal-support.md#metalmps-support-apple-silicon).
 - **VRAM:** 6 GB minimum (12 GB recommended) for SD1.5 workflows. Flux quantized pipelines require 16 GB+ for comfortable batching.
 - **Disk space:** ~15 GB for dependencies plus your checkpoints, LoRAs and flux assets.
 

--- a/docs/optimizations.md
+++ b/docs/optimizations.md
@@ -53,7 +53,7 @@ These optimizations **work together** — enabling multiple techniques simultane
 
 ---
 
-### SageAttention & SpargeAttn
+### SageAttention & SpargeAttn {#sageattention--spargeattn}
 
 **What it does:** Replaces PyTorch's default scaled dot-product attention with highly optimized CUDA kernels. SageAttention uses INT8 quantization for key/value tensors while maintaining FP16 query precision. SpargeAttn extends this with dynamic sparsity pruning, skipping redundant attention computations.
 
@@ -65,6 +65,27 @@ These optimizations **work together** — enabling multiple techniques simultane
 **Trade-offs:** None for SageAttention. SpargeAttn may introduce subtle texture variations at very high sparsity thresholds (default is conservative).
 
 [→ Full SageAttention/SpargeAttn guide](sageattention.md)
+
+---
+
+### CFG Samplers {#cfg-samplers}
+
+CFG++ Samplers are advanced sampling algorithms that incorporate Classifier-Free Guidance directly into the sampling process, providing better quality and stability compared to standard CFG.
+
+---
+
+### Multi-Scale Diffusion {#multi-scale}
+
+Multi-Scale Diffusion optimizes performance by processing images at multiple resolutions during generation, reducing computation for high-resolution areas.
+
+**When to use:**
+- High-resolution generation (>1024px)
+- When memory is limited
+- For faster previews
+
+**Trade-offs:** May reduce detail in fine areas.
+
+**Note:** In most cases, Multi-Scale Diffusion in quality mode gives better results than standard diffusion while giving a small speedup (this is explained by the upsampling process).
 
 ---
 

--- a/docs/rocm-metal-support.md
+++ b/docs/rocm-metal-support.md
@@ -1,0 +1,360 @@
+# ROCm and Metal/MPS Support
+
+LightDiffusion-Next includes comprehensive support for AMD GPUs with ROCm and Apple Silicon Macs with Metal Performance Shaders (MPS). This guide covers the platform-specific considerations and optimizations available for non-NVIDIA hardware.
+
+## ROCm Support (AMD GPUs)
+
+### Overview
+
+ROCm (Radeon Open Compute) is AMD's open-source platform for GPU computing. LightDiffusion-Next automatically detects and utilizes ROCm-compatible AMD GPUs through PyTorch's HIP backend.
+
+### Supported Hardware
+
+- **RDNA Architecture:**
+
+  - RDNA 2 (RX 6000 series) - FP16 support
+  - RDNA 3 (RX 7000 series) - FP16 and BF16 support
+
+- **CDNA Architecture:**
+
+  - CDNA (MI100)
+  - CDNA 2 (MI200 series) - FP16 and BF16 support
+  - CDNA 3 (MI300 series) - FP16 and BF16 support
+
+### Installation
+
+1. **Install ROCm drivers and runtime:**
+
+   Follow the official [ROCm installation guide](https://rocm.docs.amd.com/en/latest/deploy/linux/quick_start.html) for your Linux distribution.
+
+```bash
+   # Example for Ubuntu 22.04
+   wget https://repo.radeon.com/amdgpu-install/latest/ubuntu/jammy/amdgpu-install_latest_all.deb
+   sudo apt-get install ./amdgpu-install_latest_all.deb
+   sudo amdgpu-install --usecase=rocm
+```
+
+2. **Verify ROCm installation:**
+
+```bash
+   rocm-smi
+   /opt/rocm/bin/rocminfo
+```
+
+3. **Install PyTorch with ROCm support:**
+   
+```bash
+   pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/rocm6.0
+   ```bash
+   # Create virtual environment
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip uv
+
+   # Install PyTorch with ROCm 6.0 support (adjust version as needed)
+   uv pip install --index-url https://download.pytorch.org/whl/rocm6.0 torch torchvision
+   
+   # Install project dependencies
+   uv pip install -r requirements.txt
+```
+
+4. **Launch LightDiffusion-Next:**
+
+```bash
+   streamlit run streamlit_app.py --server.address=0.0.0.0 --server.port=8501
+```
+
+### ROCm-Specific Features
+
+#### Automatic Detection
+
+LightDiffusion-Next automatically detects ROCm GPUs at startup and reports them in the logs:
+
+```
+Device: cuda:0 AMD Radeon RX 7900 XTX (ROCm) : 
+```
+
+#### Memory Management
+
+- **Cache Management:** ROCm uses a more conservative cache clearing strategy compared to CUDA. Cache is only cleared when explicitly forced to prevent memory fragmentation issues.
+- **Memory Statistics:** Full memory statistics are available through the standard PyTorch CUDA API (which works transparently with ROCm).
+
+#### Precision Support
+
+- **FP16:** Fully supported on all RDNA and CDNA architectures
+- **BF16:** Supported on RDNA 3+ and CDNA 2+ GPUs (automatically detected)
+- **FP32:** Always available as fallback
+
+#### Attention Mechanisms
+
+| Feature | ROCm Support | Notes |
+|---------|--------------|-------|
+| PyTorch Scaled Dot-Product Attention (SDPA) | ✅ Yes | Default and recommended |
+| PyTorch Flash Attention | ✅ Yes | Available on RDNA 3 and CDNA 2+ |
+| xformers | ✅ Yes | Works with ROCm builds of xformers |
+| SageAttention | ❌ No | CUDA-only kernels |
+| SpargeAttn | ❌ No | CUDA-only kernels |
+
+**Recommendation:** Use PyTorch's built-in attention (SDPA) on ROCm for best compatibility. Install xformers ROCm build for additional optimizations.
+
+### Performance Tips
+
+1. **Use BF16 on supported GPUs:**
+
+   - RDNA 3 (RX 7000 series) and CDNA 2+ support BF16 natively
+   - BF16 provides better numerical stability than FP16
+
+2. **Enable PyTorch attention:**
+
+   - Automatically enabled for PyTorch 2.0+
+   - Provides good performance without CUDA-specific optimizations
+
+3. **Install ROCm-compatible xformers:**
+   
+```bash
+   # Build xformers from source for ROCm
+   git clone https://github.com/facebookresearch/xformers.git
+   cd xformers
+   git submodule update --init --recursive
+   pip install -e . --no-build-isolation
+```
+
+4. **Monitor GPU utilization:**
+
+```bash
+   watch -n 1 rocm-smi
+```
+
+### Known Limitations
+
+- **SageAttention and SpargeAttn:** These optimizations use CUDA-specific kernels and are not available on ROCm. The system automatically falls back to PyTorch SDPA.
+- **Stable-Fast:** May have limited support depending on ROCm version. Test compilation before relying on it.
+- **Driver Maturity:** Ensure you're using the latest ROCm version for best stability and performance.
+
+---
+
+## Metal/MPS Support (Apple Silicon)
+
+### Overview
+
+Metal Performance Shaders (MPS) provides GPU acceleration on Apple Silicon Macs (M1, M2, M3 series). LightDiffusion-Next automatically detects and utilizes MPS when running on macOS.
+
+### Supported Hardware
+
+- **Apple Silicon:**
+
+  - M1, M1 Pro, M1 Max, M1 Ultra
+  - M2, M2 Pro, M2 Max, M2 Ultra
+  - M3, M3 Pro, M3 Max
+  - All future M-series chips
+
+### Installation
+
+1. **Ensure macOS is up to date:**
+
+   - macOS 12.3 (Monterey) or later required
+   - macOS 13+ (Ventura) recommended for best performance
+
+2. **Install Python 3.10:**
+
+```bash
+   # Using Homebrew
+   brew install python@3.10
+```
+
+3. **Create virtual environment and install dependencies:**
+
+```bash
+   python3.10 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+
+   # Install PyTorch with MPS support
+   pip install torch torchvision torchaudio
+   
+   # Install project dependencies
+   pip install -r requirements.txt
+```
+
+4. **Launch LightDiffusion-Next:**
+
+```bash
+   streamlit run streamlit_app.py --server.address=0.0.0.0 --server.port=8501
+```
+
+### MPS-Specific Features
+
+#### Automatic Detection
+
+MPS is automatically detected and enabled on compatible hardware:
+
+```
+Device: mps
+VAE dtype: torch.float16
+Set vram state to: SHARED
+```
+
+#### Memory Management
+
+- **Unified Memory:** Apple Silicon uses unified memory shared between CPU and GPU
+- **VRAM State:** Automatically set to `SHARED` mode
+- **Cache Management:** Uses `torch.mps.empty_cache()` for memory cleanup
+
+#### Precision Support
+
+- **FP16:** Fully supported and recommended (default)
+- **FP32:** Supported but slower
+- **BF16:** Not supported on MPS backend
+
+#### Attention Mechanisms
+
+| Feature | MPS Support | Notes |
+|---------|-------------|-------|
+| PyTorch Scaled Dot-Product Attention (SDPA) | ✅ Yes | Default and recommended |
+| PyTorch Flash Attention | ❌ No | Not available on MPS |
+| xformers | ❌ No | MPS backend not supported |
+| SageAttention | ❌ No | CUDA/MPS incompatible |
+| SpargeAttn | ❌ No | CUDA-only kernels |
+
+**Recommendation:** Use PyTorch's built-in attention (SDPA) on MPS. It's well-optimized for Apple Silicon.
+
+### Performance Tips
+
+- **Use FP16 precision:**
+
+MPS works best with FP16  
+Automatically enabled by LightDiffusion-Next
+
+- **Optimize batch sizes:**
+
+Start with smaller batch sizes and increase gradually  
+Monitor memory usage through Activity Monitor
+
+- **Keep macOS updated:**
+
+Apple regularly improves MPS performance in system updates  
+
+- **Close unnecessary applications:**
+
+Unified memory is shared with system processes  
+Free up RAM for better GPU performance
+
+- **Monitor GPU usage:**
+
+```bash
+   # Use Activity Monitor -> GPU tab
+   # Or use powermetrics (requires sudo):
+   sudo powermetrics --samplers gpu_power -i 1000
+```
+
+### Known Limitations
+
+- **Non-blocking transfers:** Not supported; MPS operations are blocking
+- **Advanced optimizations:** SageAttention, SpargeAttn, and xformers are not available
+- **BF16:** Not supported on MPS backend
+- **Memory pressure:** System may swap under high memory load due to unified architecture
+
+### Unified Memory Considerations
+
+Apple Silicon's unified memory architecture means:
+
+- GPU and CPU share the same physical memory pool
+- Less memory copying between devices
+- System processes compete for the same memory
+- Available VRAM depends on total system RAM and current usage
+
+**Recommended RAM:**
+
+- 16 GB: SD1.5 models at moderate resolutions
+- 32 GB: Comfortable for most workflows including Flux (with quantization)
+- 64 GB+: Professional workflows with large batch sizes
+
+---
+
+## Comparison Table
+
+| Feature | NVIDIA (CUDA) | AMD (ROCm) | Apple (MPS) |
+|---------|---------------|------------|-------------|
+| FP16 | ✅ Full | ✅ Full | ✅ Full |
+| BF16 | ✅ Full | ✅ RDNA3+/CDNA2+ | ❌ No |
+| PyTorch SDPA | ✅ Yes | ✅ Yes | ✅ Yes |
+| Flash Attention | ✅ Yes | ✅ RDNA3+/CDNA2+ | ❌ No |
+| xformers | ✅ Yes | ✅ Build from source | ❌ No |
+| SageAttention | ✅ Yes | ❌ No | ❌ No |
+| SpargeAttn | ✅ Yes (CC 8.0-9.0) | ❌ No | ❌ No |
+| Stable-Fast | ✅ Yes | ⚠️ Limited | ❌ No |
+| Memory Management | ✅ Dedicated VRAM | ✅ Dedicated VRAM | ⚠️ Unified Memory |
+
+---
+
+## Troubleshooting
+
+### ROCm Issues
+
+**Problem:** PyTorch doesn't detect ROCm GPU
+
+```bash
+# Check ROCm installation
+rocm-smi
+rocminfo | grep "Name:"
+
+# Verify PyTorch sees GPU
+python -c "import torch; print(torch.cuda.is_available()); print(torch.version.hip)"
+```
+
+**Problem:** Out of memory errors
+
+- Reduce batch size
+- Enable lower VRAM mode in settings
+- Close other GPU-using applications
+- Check with `rocm-smi` for memory usage
+
+**Problem:** Slow performance
+
+- Verify you're using the correct ROCm-optimized PyTorch build
+- Check GPU utilization with `rocm-smi`
+- Ensure FP16 or BF16 is enabled (check logs)
+
+### MPS Issues
+
+**Problem:** MPS not detected
+
+```bash
+# Verify MPS support
+python -c "import torch; print(torch.backends.mps.is_available())"
+```
+- Ensure macOS 12.3+
+- Update to latest macOS version
+- Reinstall PyTorch
+
+**Problem:** Memory warnings or crashes
+
+- Reduce batch size
+- Close other applications to free unified memory
+- Check Activity Monitor for memory pressure
+
+**Problem:** Slower than expected performance
+
+- Verify FP16 is being used (check logs)
+- Close background applications
+- Update to latest macOS version for performance improvements
+- Some models may be CPU-bound on older M1 chips
+
+---
+
+## Getting Help
+
+For platform-specific issues:
+
+1. Check the [FAQ](faq.md) for common questions
+2. Review PyTorch's platform-specific documentation:
+   - [ROCm installation](https://pytorch.org/get-started/locally/#linux-rocm)
+   - [MPS backend](https://pytorch.org/docs/stable/notes/mps.html)
+3. Open an issue on GitHub with:
+   - Platform details (GPU model, driver version, OS)
+   - LightDiffusion-Next startup logs
+   - Output of `python -c "import torch; print(torch.__version__); print(torch.version.hip if hasattr(torch.version, 'hip') else 'CUDA'); print(torch.cuda.is_available())"`
+
+---
+
+**Note:** This documentation reflects the current state of ROCm and MPS support in PyTorch and LightDiffusion-Next. As these platforms mature, more optimizations and features may become available.

--- a/docs/wavespeed.md
+++ b/docs/wavespeed.md
@@ -22,7 +22,7 @@ Diffusion models denoise images iteratively over 20-50 steps. Researchers observ
 
 WaveSpeed caches the expensive high-level computations and reuses them for several steps, only updating low-level details cheaply.
 
-### DeepCache (UNet Models)
+### DeepCache (UNet Models) {#deepcache}
 
 DeepCache targets the middle and output blocks of the UNet architecture:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
   - Overview: index.md
   - Getting Started:
     - Installation: installation.md
+    - ROCm and MPS Setup: rocm-metal-support.md
     - First Run & UI Tour: usage.md
     - Workflow Playbook: examples.md
   - Deep Dive:

--- a/src/Device/Device.py
+++ b/src/Device/Device.py
@@ -214,6 +214,19 @@ def is_nvidia() -> bool:
     return False
 
 
+def is_rocm() -> bool:
+    """#### Checks if user has an AMD GPU with ROCm
+
+    #### Returns
+        - `bool`: Whether the GPU is AMD with ROCm
+    """
+    global cpu_state
+    if cpu_state == CPUState.GPU:
+        if torch.version.hip:
+            return True
+    return False
+
+
 ENABLE_PYTORCH_ATTENTION = False
 
 VAE_DTYPE = torch.float32
@@ -230,6 +243,15 @@ try:
                 >= 8
             ):
                 VAE_DTYPE = torch.bfloat16
+    elif is_rocm():
+        # ROCm supports PyTorch attention on modern AMD GPUs
+        torch_version = torch.version.__version__
+        if int(torch_version[0]) >= 2:
+            if ENABLE_PYTORCH_ATTENTION is False:
+                ENABLE_PYTORCH_ATTENTION = True
+        # Most modern AMD GPUs (RDNA 2+, CDNA) support bfloat16
+        if torch.cuda.is_available() and torch.cuda.is_bf16_supported():
+            VAE_DTYPE = torch.bfloat16
 except:
     pass
 
@@ -237,9 +259,11 @@ if is_intel_xpu():
     VAE_DTYPE = torch.bfloat16
 
 if ENABLE_PYTORCH_ATTENTION:
-    torch.backends.cuda.enable_math_sdp(True)
-    torch.backends.cuda.enable_flash_sdp(True)
-    torch.backends.cuda.enable_mem_efficient_sdp(True)
+    # Enable SDP backends for CUDA and ROCm (both use torch.backends.cuda)
+    if torch.cuda.is_available():
+        torch.backends.cuda.enable_math_sdp(True)
+        torch.backends.cuda.enable_flash_sdp(True)
+        torch.backends.cuda.enable_mem_efficient_sdp(True)
 
 
 FORCE_FP32 = False
@@ -278,9 +302,11 @@ def get_torch_device_name(device: torch.device) -> str:
                 allocator_backend = torch.cuda.get_allocator_backend()
             except:
                 allocator_backend = ""
-            return "{} {} : {}".format(
-                device, torch.cuda.get_device_name(device), allocator_backend
-            )
+            device_name = torch.cuda.get_device_name(device)
+            if is_rocm():
+                return "{} {} (ROCm) : {}".format(device, device_name, allocator_backend)
+            else:
+                return "{} {} : {}".format(device, device_name, allocator_backend)
         else:
             return "{}".format(device.type)
     elif is_intel_xpu():
@@ -1287,6 +1313,9 @@ def sageattention_enabled() -> bool:
         return False
     if directml_enabled:
         return False
+    if is_rocm():
+        # SageAttention is CUDA-only, not compatible with ROCm
+        return False
     if torch.cuda.is_available():
         try:
             major, _ = torch.cuda.get_device_capability()
@@ -1324,6 +1353,9 @@ def spargeattn_enabled() -> bool:
     if is_intel_xpu():
         return False
     if directml_enabled:
+        return False
+    if is_rocm():
+        # SpargeAttn is CUDA-only, not compatible with ROCm
         return False
     if torch.cuda.is_available():
         try:
@@ -1363,6 +1395,7 @@ def xformers_enabled() -> bool:
         return False
     if directml_enabled:
         return False
+    # xformers works on both CUDA and ROCm
     return XFORMERS_IS_AVAILABLE
 
 
@@ -1396,8 +1429,17 @@ def pytorch_attention_flash_attention() -> bool:
     """
     global ENABLE_PYTORCH_ATTENTION
     if ENABLE_PYTORCH_ATTENTION:
-        if is_nvidia():  # pytorch flash attention only works on Nvidia
+        if is_nvidia():
+            # PyTorch flash attention works well on Nvidia GPUs
             return True
+        if is_rocm():
+            # PyTorch SDPA supports ROCm with flash attention on modern AMD GPUs
+            # RDNA 3 and CDNA 2+ architectures
+            try:
+                # Check if flash attention backend is available
+                return True
+            except:
+                pass
     return False
 
 
@@ -1559,7 +1601,8 @@ def should_use_fp16(
     if is_intel_xpu():
         return True
 
-    if torch.version.hip:
+    if is_rocm():
+        # ROCm GPUs support FP16 - all RDNA and CDNA architectures
         return True
 
     if torch.cuda.is_available():
@@ -1658,6 +1701,18 @@ def should_use_bf16(
     if is_intel_xpu():
         return True
 
+    if is_rocm():
+        # ROCm: Check if bfloat16 is supported (CDNA2+ and RDNA3+ architectures)
+        try:
+            bf16_works = torch.cuda.is_bf16_supported()
+            if bf16_works or manual_cast:
+                free_model_memory = get_free_memory() * 0.9 - minimum_inference_memory()
+                if (not prioritize_performance) or model_params * 4 > free_model_memory:
+                    return True
+        except:
+            pass
+        return False
+
     if device is None:
         device = torch.device("cuda")
 
@@ -1687,11 +1742,14 @@ def soft_empty_cache(force: bool = False) -> None:
     elif is_intel_xpu():
         torch.xpu.empty_cache()
     elif torch.cuda.is_available():
-        if (
-            force or is_nvidia()
-        ):  # This seems to make things worse on ROCm so I only do it for cuda
+        if force or is_nvidia():
+            # NVIDIA: Always empty cache when forced or by default
             torch.cuda.empty_cache()
             torch.cuda.ipc_collect()
+        elif is_rocm() and force:
+            # ROCm: Only empty cache when explicitly forced
+            # ROCm's memory allocator can be sensitive to frequent cache clearing
+            torch.cuda.empty_cache()
 
 
 def unload_all_models() -> None:


### PR DESCRIPTION
This pull request adds comprehensive support and documentation for running LightDiffusion-Next on AMD GPUs (ROCm) and Apple Silicon (Metal/MPS), alongside NVIDIA GPUs. It introduces a new setup guide, expands installation instructions, and updates device detection and optimization logic throughout the codebase to handle ROCm and MPS platforms. There are also improvements to documentation for new features and platform-specific optimizations.

**Platform Support and Documentation:**

* Added a detailed `rocm-metal-support.md` guide covering setup, compatibility, feature support, and troubleshooting for AMD ROCm and Apple Silicon MPS platforms.
* Installation instructions in `README.md` and `docs/installation.md` now explicitly mention AMD (ROCm) and Apple Silicon (MPS) support, including links to the new setup guide and platform-specific requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R105) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L7-R14) [[3]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R22)

**Device Detection and Backend Logic:**

* Introduced `is_rocm()` detection and updated device logic in `Device.py` to properly enable/disable features (e.g., SageAttention, SpargeAttn, xformers, PyTorch attention) based on ROCm or MPS presence. This includes correct dtype selection and memory/cache management for each platform. [[1]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR217-R229) [[2]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR246-R263) [[3]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL281-R309) [[4]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1316-R1318) [[5]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1357-R1359) [[6]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1398) [[7]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1399-R1442) [[8]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1562-R1605) [[9]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1704-R1715) [[10]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1690-R1752)

**Documentation Enhancements:**

* Added/updated documentation for new and existing optimizations, including section anchors and clarifications for SageAttention, SpargeAttn, CFG Samplers, and Multi-Scale Diffusion. [[1]](diffhunk://#diff-bf19ef7a0c6b5d8b7e802c9fb9901c5b3b1f5b8f36d08cca8450ed7757e0c475L56-R56) [[2]](diffhunk://#diff-bf19ef7a0c6b5d8b7e802c9fb9901c5b3b1f5b8f36d08cca8450ed7757e0c475R71-R91) [[3]](diffhunk://#diff-feaff1b7036cd9e3c5a0b2acead6e29981d10f7b8f3e1457928b32ea10d92bccL25-R25)

These changes collectively make LightDiffusion-Next more accessible and performant across a wider range of hardware, with clear guidance and robust platform detection.

**References:** [[1]](diffhunk://#diff-ebbec1b32e8a563f3b114bd735687cead08b339ea27be8190445dfea12d68a7aR1-R360) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R102-R105) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L7-R14) [[4]](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R22) [[5]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR217-R229) [[6]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR246-R263) [[7]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL281-R309) [[8]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1316-R1318) [[9]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1357-R1359) [[10]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1398) [[11]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1399-R1442) [[12]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1562-R1605) [[13]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eR1704-R1715) [[14]](diffhunk://#diff-d877e9384e2488d7d0118e9246cbf9d19dd73c8471a4cfec90fa5c18b963a82eL1690-R1752) [[15]](diffhunk://#diff-bf19ef7a0c6b5d8b7e802c9fb9901c5b3b1f5b8f36d08cca8450ed7757e0c475L56-R56) [[16]](diffhunk://#diff-bf19ef7a0c6b5d8b7e802c9fb9901c5b3b1f5b8f36d08cca8450ed7757e0c475R71-R91) [[17]](diffhunk://#diff-feaff1b7036cd9e3c5a0b2acead6e29981d10f7b8f3e1457928b32ea10d92bccL25-R25)